### PR TITLE
Fix the authenticator to work behind a proxy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,13 +12,13 @@ This project provides an opens source MobileConnect Authenticator plug-in for th
 System Requirements
 ~~~~~~~~~~~~~~~~~~~
 
-* Curity Identity Server 2.4.0 and `its system requirements <https://developer.curity.io/docs/latest/system-admin-guide/system-requirements.html>`_
+* Curity Identity Server 7.0.2 and `its system requirements <https://developer.curity.io/docs/latest/system-admin-guide/system-requirements.html>`_
 
 Requirements for Building from Source
 """""""""""""""""""""""""""""""""""""
 
 * Maven 3
-* Java JDK v. 8
+* Java SDK 17 or later
 
 Compiling the Plug-in from Source
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -59,17 +59,18 @@ When you view the app's configuration after creating it, you'll find the ``Clien
 
 MobileConnect will also display the ``Authorized Redirect URLs`` in the new app's configuration. One of these need to match the yet-to-be-created MobileConnect authenticator instance in Curity. The default will not work, and, if used, will result in an error. This should be updated to some URL that follows the pattern ``$baseUrl/$authenticationEndpointPath/$identityserver.plugins.authenticators.mobile-connectAuthnticatorId/callback``, where each of these URI components has the following meaning:
 
-============================== ============================================================================================
-URI Component                  Meaning
------------------------------- --------------------------------------------------------------------------------------------
-``baseUrl``                    The base URL of the server (defined on the ``System --> General`` page of the
-                               admin GUI). If this value is not set, then the server scheme, name, and port should be
-                               used (e.g., ``https://localhost:8443``).
-``authenticationEndpointPath`` The path of the authentication endpoint. In the admin GUI, this is located in the
-                               authentication profile's ``Endpoints`` tab for the endpoint that has the type
-                               ``auth-authentication``.
-``identityserver.plugins.authenticators.mobile-connectAuthenticatorId``    This is the name given to the MobileConnect authenticator when defining it (e.g., ``identityserver.plugins.authenticators.mobile-connect1``).
-============================== ============================================================================================
+======================================================================= =======================================================================================
+URI Component                                                           Meaning
+----------------------------------------------------------------------- ---------------------------------------------------------------------------------------
+``baseUrl``                                                             The base URL of the server (defined on the ``System --> General`` page of the
+                                                                        admin GUI). If this value is not set, then the server scheme, name, and port should be
+                                                                        used (e.g., ``https://localhost:8443``).
+``authenticationEndpointPath``                                          The path of the authentication endpoint. In the admin GUI, this is located in the
+                                                                        authentication profile's ``Endpoints`` tab for the endpoint that has the type
+                                                                        ``auth-authentication``.
+``identityserver.plugins.authenticators.mobile-connectAuthenticatorId`` This is the name given to the MobileConnect authenticator when defining it (e.g.,
+                                                                        ``identityserver.plugins.authenticators.mobile-connect1``).
+======================================================================= =======================================================================================
 
     .. figure:: docs/images/create-identityserver.plugins.authenticators.mobile-connect-app2.png
         :align: center

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.curityVersion>7.0.2</project.curityVersion>
+        <project.curityVersion>7.1.0</project.curityVersion>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
 
     <groupId>io.curity.identityserver.plugin</groupId>
     <artifactId>identityserver.plugins.authenticators.mobile-connect</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
 
     <name>Curity MobileConnect Authenticator</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.curityVersion>2.4.0</project.curityVersion>
+        <project.curityVersion>7.0.2</project.curityVersion>
     </properties>
 
     <build>
@@ -22,8 +22,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.22</version>
+            <version>1.7.36</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/io/curity/identityserver/plugin/authentication/CallbackRequestHandler.java
+++ b/src/main/java/io/curity/identityserver/plugin/authentication/CallbackRequestHandler.java
@@ -34,6 +34,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import static io.curity.identityserver.plugin.authentication.RedirectUriUtil.createRedirectUri;
+
 public class CallbackRequestHandler implements AuthenticatorRequestHandler<CallbackRequestModel>
 {
     private final static Logger _logger = LoggerFactory.getLogger(CallbackRequestHandler.class);
@@ -92,12 +94,14 @@ public class CallbackRequestHandler implements AuthenticatorRequestHandler<Callb
 
     private Map<String, Object> redeemCodeForTokens(CallbackRequestModel requestModel)
     {
+        var redirectUri = createRedirectUri(_authenticatorInformationProvider, _exceptionFactory);
+
         HttpResponse tokenResponse = getWebServiceClient()
                 .withPath("/oauth/v2/accessToken")
                 .request()
                 .contentType("application/x-www-form-urlencoded")
                 .body(getFormEncodedBodyFrom(createPostData(_config.getClientId(), _config.getClientSecret(),
-                        requestModel.getCode(), requestModel.getRequestUrl())))
+                        requestModel.getCode(), redirectUri)))
                 .method("POST")
                 .response();
         int statusCode = tokenResponse.statusCode();

--- a/src/main/java/io/curity/identityserver/plugin/authentication/MobileConnectAuthenticatorRequestHandler.java
+++ b/src/main/java/io/curity/identityserver/plugin/authentication/MobileConnectAuthenticatorRequestHandler.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
+import static io.curity.identityserver.plugin.authentication.RedirectUriUtil.createRedirectUri;
 import static io.curity.identityserver.plugin.descriptor.MobileConnectAuthenticatorPluginDescriptor.CALLBACK;
 
 public class MobileConnectAuthenticatorRequestHandler implements AuthenticatorRequestHandler<Request>
@@ -48,7 +49,7 @@ public class MobileConnectAuthenticatorRequestHandler implements AuthenticatorRe
     {
         _logger.debug("GET request received for authentication");
 
-        String redirectUri = createRedirectUri();
+        String redirectUri = createRedirectUri(_authenticatorInformationProvider, _exceptionFactory);
         String state = UUID.randomUUID().toString();
         Map<String, Collection<String>> queryStringArguments = new LinkedHashMap<>(5);
         Set<String> scopes = new LinkedHashSet<>(7);
@@ -67,20 +68,6 @@ public class MobileConnectAuthenticatorRequestHandler implements AuthenticatorRe
 
         throw _exceptionFactory.redirectException(AUTHORIZATION_ENDPOINT,
                 RedirectStatusCode.MOVED_TEMPORARILY, queryStringArguments, false);
-    }
-
-    private String createRedirectUri()
-    {
-        try
-        {
-            URI authUri = _authenticatorInformationProvider.getFullyQualifiedAuthenticationUri();
-
-            return new URL(authUri.toURL(), authUri.getPath() + "/" + CALLBACK).toString();
-        } catch (MalformedURLException e)
-        {
-            throw _exceptionFactory.internalServerException(ErrorCode.INVALID_REDIRECT_URI,
-                    "Could not create redirect URI");
-        }
     }
 
     @Override

--- a/src/main/java/io/curity/identityserver/plugin/authentication/RedirectUriUtil.java
+++ b/src/main/java/io/curity/identityserver/plugin/authentication/RedirectUriUtil.java
@@ -1,0 +1,31 @@
+package io.curity.identityserver.plugin.authentication;
+
+import se.curity.identityserver.sdk.errors.ErrorCode;
+import se.curity.identityserver.sdk.service.ExceptionFactory;
+import se.curity.identityserver.sdk.service.authentication.AuthenticatorInformationProvider;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static io.curity.identityserver.plugin.descriptor.MobileConnectAuthenticatorPluginDescriptor.CALLBACK;
+
+final class RedirectUriUtil
+{
+    private RedirectUriUtil()
+    {
+    }
+
+    static String createRedirectUri(AuthenticatorInformationProvider authenticatorInformationProvider, ExceptionFactory exceptionFactory)
+    {
+        try
+        {
+            var authUri = authenticatorInformationProvider.getFullyQualifiedAuthenticationUri();
+
+            return new URL(authUri.toURL(), authUri.getPath() + "/" + CALLBACK).toString();
+        } catch (MalformedURLException e)
+        {
+            throw exceptionFactory.internalServerException(ErrorCode.INVALID_REDIRECT_URI,
+                    "Could not create redirect URI");
+        }
+    }
+}

--- a/src/main/java/io/curity/identityserver/plugin/authentication/RedirectUriUtil.java
+++ b/src/main/java/io/curity/identityserver/plugin/authentication/RedirectUriUtil.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2022 Curity AB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package io.curity.identityserver.plugin.authentication;
 
 import se.curity.identityserver.sdk.errors.ErrorCode;

--- a/src/main/java/io/curity/identityserver/plugin/config/MobileConnectAuthenticatorPluginConfig.java
+++ b/src/main/java/io/curity/identityserver/plugin/config/MobileConnectAuthenticatorPluginConfig.java
@@ -21,7 +21,7 @@ public interface MobileConnectAuthenticatorPluginConfig extends Configuration {
     @Description("Secret key")
     String getClientSecret();
 
-    @Description("The HTTP client with any proxy and TLS settings that will be used to connect to LinkedIn")
+    @Description("The HTTP client with any proxy and TLS settings that will be used to connect to MobileConnect")
     Optional<HttpClient> getHttpClient();
 
     SessionManager getSessionManager();


### PR DESCRIPTION
Unfortunately, I couldn't test the fix. Links to MobileConnect resources that we have in our readme no longer work. I found this page: https://mobileconnect.io/getting-started/ which seems to be the new page for MobileConnect, but their links to dev portal or documentation won't work either.